### PR TITLE
Fix inaccurate color sample when at the extreme left of the canvas

### DIFF
--- a/src/acolorpicker.js
+++ b/src/acolorpicker.js
@@ -118,7 +118,7 @@ function canvasHelper(canvas) {
             // gradiente con il colore relavito a lo HUE da sinistra a destra partendo da trasparente a opaco
             // la combinazione del gradiente bianco/nero e questo permette di avere un canvas dove
             // sull'asse delle ordinate è espressa la saturazione, e sull'asse delle ascisse c'è la luminosità
-            const colorGradient = ctx.createLinearGradient(0, 0, width - 1, 0);
+            const colorGradient = ctx.createLinearGradient(1, 0, width - 1, 0);
             colorGradient.addColorStop(0, `hsla(${hue}, 100%, 50%, 0)`);
             colorGradient.addColorStop(1, `hsla(${hue}, 100%, 50%, 1)`);
             // applico i gradienti


### PR DESCRIPTION
When selecting a pure white color (#ffffff) the cursor can be
moved to the far left of the canvas. However the closest to white it
could ever get would be #fffefe.

It seems that the issue had to do with the linear gradient used to
display the current hue.

A linear gradient can be created with: ctx.createLinearGradient(x, y, ...)
where x == 0 is the far left of the color picker.  The actual value pulled
from the canvas at x == 0 with ctx.getImageData() is never actually
pure white though.

If the gradient is started one pixel offset to the right then a pure
white color can be selected: ctx.createLinearGradient(1, 0, ...)